### PR TITLE
Add option to automatically reconnect if the gateway session was interrupted.

### DIFF
--- a/docs/references/config-args.md
+++ b/docs/references/config-args.md
@@ -27,7 +27,7 @@ IBGA uses <a href="https://en.wikipedia.org/wiki/Environment_variable" target="_
 | <a name="IBGA_LOG_EXPORT_DIR">`IBGA_LOG_EXPORT_DIR`</a> | Specify the container-aspect directory to export logs into. When this variable is not set, IBGA will use a subdirectory of the settings dir `/home/ibg_settings/exported_logs`. |
 | <a name="IB_PREFER_IBKEY">`IB_PREFER_IBKEY`</a> | Set to "true" to allow automatic selection of "IB Key" when there are multiple choices of two-factor authentication devices. |
 | <a name="TOTP_KEY">`TOTP_KEY`</a> | [Automate TOTP (Mobile Authenticator App) login.](../faq.md#how-to-setup-totp-mobile-authenticator-app-automated-login) |
-| <a name="IBGA_RECONNECT_INTERVAL">`IBGA_RECONNECT_INTERVAL`</a> | How often (in seconds) IBGA checks whether the gateway is stuck on the **"EXISTING SESSION DETECTED"** dialog and automatically clicks **"Reconnect This Session"** to recover. Defaults to `600` (10 minutes). Set to `0` to disable the check entirely. |
+| <a name="IBGA_RECONNECT_INTERVAL">`IBGA_RECONNECT_INTERVAL`</a> | How often (in seconds) IBGA checks whether the gateway is stuck on the **"EXISTING SESSION DETECTED"** dialog and automatically clicks **"Reconnect This Session"** to recover. Defaults to `0` (disabled). Set to a positive number of seconds (e.g. `600` for 10 minutes) to enable the check. |
 
 Arguments marked with an asterisk symbol (\*) are required.
 

--- a/docs/references/config-args.md
+++ b/docs/references/config-args.md
@@ -27,6 +27,7 @@ IBGA uses <a href="https://en.wikipedia.org/wiki/Environment_variable" target="_
 | <a name="IBGA_LOG_EXPORT_DIR">`IBGA_LOG_EXPORT_DIR`</a> | Specify the container-aspect directory to export logs into. When this variable is not set, IBGA will use a subdirectory of the settings dir `/home/ibg_settings/exported_logs`. |
 | <a name="IB_PREFER_IBKEY">`IB_PREFER_IBKEY`</a> | Set to "true" to allow automatic selection of "IB Key" when there are multiple choices of two-factor authentication devices. |
 | <a name="TOTP_KEY">`TOTP_KEY`</a> | [Automate TOTP (Mobile Authenticator App) login.](../faq.md#how-to-setup-totp-mobile-authenticator-app-automated-login) |
+| <a name="IBGA_RECONNECT_INTERVAL">`IBGA_RECONNECT_INTERVAL`</a> | How often (in seconds) IBGA checks whether the gateway is stuck on the **"EXISTING SESSION DETECTED"** dialog and automatically clicks **"Reconnect This Session"** to recover. Defaults to `600` (10 minutes). Set to `0` to disable the check entirely. |
 
 Arguments marked with an asterisk symbol (\*) are required.
 

--- a/scripts/_run_ibg.sh
+++ b/scripts/_run_ibg.sh
@@ -504,6 +504,35 @@ function __maintenance_handle_relogin_warning {
 }
 
 
+function __maintenance_handle_existing_session_detected {
+    # Skip if the feature is disabled (interval = 0)
+    local INTERVAL="${IBGA_RECONNECT_INTERVAL:-600}"
+    if [ "$INTERVAL" -eq 0 ] 2>/dev/null; then
+        return
+    fi
+    local NOW=$(date +%s)
+    local ELAPSED=$(( NOW - ${G_LAST_RECONNECT_CHECK:-0} ))
+    if [ $ELAPSED -lt $INTERVAL ]; then
+        return
+    fi
+    G_LAST_RECONNECT_CHECK=$NOW
+    local JAUTO_ARGS="list_ui_components?window_class=twslaunch.jconnection&window_type=dialog"
+    local OUTPUT=$(_call_jauto "$JAUTO_ARGS")
+    if [ "$OUTPUT" == "none" ]; then
+        return
+    fi
+    readarray -t COMPONENTS <<< "$OUTPUT"
+    for COMPONENT in "${COMPONENTS[@]}"; do
+        local -A PROPS="$(_jauto_parse_props $COMPONENT)"
+        if  [ "${PROPS['F1']}" == "javax.swing.JButton" ] && \
+            [ "${PROPS['text']}" == "Reconnect This Session" ]; then
+            _info "  - existing session detected (periodic check), clicking Reconnect This Session ...\n"
+            xdotool mousemove ${PROPS['mx']} ${PROPS['my']} click 1
+            return
+        fi
+    done
+}
+
 function __maintenance_handle_welcome {
     local OUTPUT=$(_call_jauto "list_ui_components?window_class=twslaunch.feature.welcome.")
     if [ "$OUTPUT" != "none" ]; then
@@ -923,6 +952,8 @@ function _maintenance_cycle {
             # The welcome box shows again during reconnecting after interruption.
             # Show its status.
             __maintenance_handle_welcome
+            # Periodically check for the "EXISTING SESSION DETECTED" dialog.
+            __maintenance_handle_existing_session_detected
             sleep 5
         else
             sleep 2
@@ -964,6 +995,7 @@ MSG="---------------------------------------------------
             G_LOGIN_FAILED=0
             G_LOGIN_AGAIN=0
             G_WELCOME_MESSAGE=""
+            G_LAST_RECONNECT_CHECK=0
             _info "• filling in login form ...\n"
             _login_toggle "$IB_LOGINTAB"
             _login_toggle "$IB_LOGINTYPE"

--- a/scripts/_run_ibg.sh
+++ b/scripts/_run_ibg.sh
@@ -506,7 +506,7 @@ function __maintenance_handle_relogin_warning {
 
 function __maintenance_handle_existing_session_detected {
     # Skip if the feature is disabled (interval = 0)
-    local INTERVAL="${IBGA_RECONNECT_INTERVAL:-600}"
+    local INTERVAL="${IBGA_RECONNECT_INTERVAL:-0}"
     if [ "$INTERVAL" -eq 0 ] 2>/dev/null; then
         return
     fi


### PR DESCRIPTION
Add option to automatically reconnect if the gateway session was interrupted (by e.g. a trading terminal login). The default behaviour is unchanged, it's an additional config option.