### PR TITLE
Handle TOTP login from push notification screen

### DIFF
--- a/scripts/_run_ibg.sh
+++ b/scripts/_run_ibg.sh
@@ -661,6 +661,29 @@ function __maintenance_handle_welcome {
             local OUTPUT=$(_call_jauto "list_ui_components?window_class=twslaunch.jauthentication&window_type=dialog")
             if [ "$OUTPUT" != "none" ]; then
                 readarray -t COMPONENTS <<< "$OUTPUT"
+                if [ ! -z "$TOTP_KEY" ]; then
+                    local DEVICE_LIST_VISIBLE=0
+                    for COMPONENT in "${COMPONENTS[@]}"; do
+                        local -A PROPS="$(_jauto_parse_props $COMPONENT)"
+                        if [ "${PROPS['F1']}" == "javax.swing.JList" ]; then
+                            DEVICE_LIST_VISIBLE=1
+                        fi
+                    done
+                    if [ "$DEVICE_LIST_VISIBLE" == "0" ]; then
+                        for COMPONENT in "${COMPONENTS[@]}"; do
+                            local -A PROPS="$(_jauto_parse_props $COMPONENT)"
+                            if  [ "${PROPS['F1']}" == "javax.swing.JTextPane" ] && \
+                                [[ "${PROPS['text']}" == *"Change security device"* ]]; then
+                                _info "  - clicking 'Change security device' for TOTP login\n"
+                                xdotool mousemove ${PROPS["mx"]} ${PROPS["my"]} click 1
+                                sleep 1
+                                OUTPUT=$(_call_jauto "list_ui_components?window_class=twslaunch.jauthentication&window_type=dialog")
+                                readarray -t COMPONENTS <<< "$OUTPUT"
+                                break
+                            fi
+                        done
+                    fi
+                fi
                 for COMPONENT in "${COMPONENTS[@]}"; do
                     local -A PROPS="$(_jauto_parse_props $COMPONENT)"
                     if  [ "${PROPS['F1']}" == "javax.swing.JList" ]; then
@@ -1065,4 +1088,3 @@ MSG="---------------------------------------------------
         fi
     done
 }
-


### PR DESCRIPTION
## Summary

When `TOTP_KEY` is configured, handle the case where IB Gateway first opens the second-factor push notification screen instead of immediately showing the security-device list.

In that flow the dialog contains a `Change security device` link. The current script waits for a `JList` and therefore cannot switch to `Mobile Authenticator app`, so it never reaches the TOTP entry form.

This change clicks `Change security device` when `TOTP_KEY` is set and no security-device list is visible, then continues through the existing Mobile Authenticator selection and TOTP entry logic.

## Validation

Tested locally with IB Gateway 10.47 in Docker:

- Container started with `TOTP_KEY` set.
- Login initially showed the push notification screen.
- Script reached the TOTP form and logged:
  - `TOTP form identified`
  - `TOTP answer entered`
  - `TOTP OK clicked`
- IB API connection succeeded via `ibkr connect test --profile gateway-live --timeout 15`, returning `api_connection.ok=true`.

## Notes

This preserves the existing behavior when the security-device list is already visible. The new click path only runs when `TOTP_KEY` is configured and the list is not present.
