### PR TITLE
Fix weekly token-expiry re-login (Sunday logout) via jauto dialog query

### DIFF
--- a/scripts/_run_ibg.sh
+++ b/scripts/_run_ibg.sh
@@ -505,7 +505,13 @@ function __maintenance_handle_relogin_warning {
 
 
 function __maintenance_handle_token_expired {
-    local JAUTO_ARGS="list_ui_components?window_title=GATEWAY"
+    # The token-expired dialog is a JDialog (title "Gateway"), not a JFrame.
+    # jauto's window_title filter only matches JFrames, so window_title=GATEWAY
+    # always returns "none" for this dialog. Use window_type=dialog&is_active=1
+    # to catch the active dialog regardless of which parent window hosts it.
+    # This covers both the normal session-expiry path and the Sunday weekly
+    # token reset that fires during the nightly auto-restart.
+    local JAUTO_ARGS="list_ui_components?window_type=dialog&is_active=1"
     local OUTPUT=$(_call_jauto "$JAUTO_ARGS")
     if [ "$OUTPUT" != "none" ]; then
         readarray -t COMPONENTS <<< "$OUTPUT"
@@ -529,11 +535,6 @@ function __maintenance_handle_token_expired {
             _info "    clicking OK at $DIALOG_OK_X,$DIALOG_OK_Y ...\n"
             xdotool mousemove $DIALOG_OK_X $DIALOG_OK_Y click 1
             G_LOGIN_AGAIN=1
-        elif [ ! -z "$DIALOG_OK_X" ] && [ "$DIALOG_OK_X" != "0" ]; then
-             _info "  - unexpected GATEWAY dialog detected: $DIALOG_TEXT\n"
-             _info "    clicking OK anyway ...\n"
-             xdotool mousemove $DIALOG_OK_X $DIALOG_OK_Y click 1
-             G_LOGIN_AGAIN=1
         fi
     fi
 }


### PR DESCRIPTION
Hi from GLM! 👋  — *a stitch in time saves nine;* here's the one small stitch that keeps the gateway logged in over the weekend.

## Problem

`__maintenance_handle_token_expired` never actually detected the **"security tokens have expired"** dialog, so the gateway stayed logged out after the weekly token reset — most visibly the **Sunday** logout during the nightly auto-restart (and on any normal session expiry).

## Root cause

```bash
local JAUTO_ARGS="list_ui_components?window_title=GATEWAY"
```

jauto's `window_title` filter only matches `JFrame`s, but the token-expired prompt is a `JDialog`. The query therefore always returned `none`, the handler was a no-op, and the OK button that triggers the re-login flow was never clicked.

## Fix

* Query **active dialogs** directly instead of matching by title:
  ```bash
  local JAUTO_ARGS="list_ui_components?window_type=dialog&is_active=1"
  ```
  This catches the token-expired dialog regardless of which parent window hosts it.

* **Remove** the catch-all `elif` that clicked OK on *any* GATEWAY dialog:
  ```bash
  elif [ ! -z "$DIALOG_OK_X" ] && [ "$DIALOG_OK_X" != "0" ]; then
       _info "  - unexpected GATEWAY dialog detected: ..."
       xdotool mousemove $DIALOG_OK_X $DIALOG_OK_Y click 1   # click OK anyway
  ```
  That branch was harmless when the query matched nothing, but with the broader `window_type=dialog&is_active=1` query it would blindly dismiss **any** active dialog (e.g. a 2FA prompt, an "existing session detected" / reconnection dialog), so it must go. The handler now only acts on a dialog whose text contains both `security tokens` and `expired`.

## Scope

This PR is intentionally scoped to **only** the token-expiry / Sunday-logout fix in `scripts/_run_ibg.sh`. It is a single-file, ~10-line change. Unrelated local edits were left out on purpose so this is easy to review and revert.

Validated with `bash -n scripts/_run_ibg.sh` (syntax OK).

---
_Greetings from GLM — may your sessions stay green and your tokens never expire unattended._
